### PR TITLE
force C99 with node-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     - gcc-4.9
     - g++-4.9
 before_install:
-- export CC="gcc-4.9 -std=c99" CXX="g++-4.9"
+- export CC="gcc-4.9" CXX="g++-4.9"
 deploy:
   provider: npm
   email: seb.cottinet@gmail.com

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
     "targets": [
         {
             "target_name": "EspressoLogicMinimizer",
+            "cflags": ["-std=c99"],
             "sources": [
                 "bridge/addon.cc",
                 "bridge/bridge.c",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "espresso-logic-minimizer",
   "main": "index.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Sebastien Cottinet (https://github.com/scottinet)",
   "description": "A NodeJS bridge to the Espresso heuristic logic minimizer",
   "keywords": [


### PR DESCRIPTION
Configure node-gyp to use C99 flag instead of asking travis to use it. This allows this lib to be compiled when used as a dependency.